### PR TITLE
Add `kSecValuePersistentRef` return result key

### DIFF
--- a/security-framework-sys/src/item.rs
+++ b/security-framework-sys/src/item.rs
@@ -80,4 +80,5 @@ extern "C" {
     pub static kSecAttrAccount: CFStringRef;
     pub static kSecValueData: CFStringRef;
     pub static kSecValueRef: CFStringRef;
+    pub static kSecValuePersistentRef: CFStringRef;
 }


### PR DESCRIPTION
Adds the [`kSecValuePersistentRef`] (https://developer.apple.com/documentation/security/ksecvaluepersistentref) return result key. Supported since macOS 10.6, so no require any feature flags.